### PR TITLE
Fix hyphenation cleanup order

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,11 @@ def fix_text():
     elif fix_type == 'spaces':
         text = normalize_spaces(text)
     elif fix_type == 'all':
-        text = normalize_spaces(fix_hyphenation(fix_linebreaks(text)))
+        # When fixing everything, apply hyphenation fix before removing
+        # line breaks so that words split across lines are joined correctly.
+        text = fix_hyphenation(text)
+        text = fix_linebreaks(text)
+        text = normalize_spaces(text)
     
     return jsonify({'fixed_text': text})
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app
+
+
+def test_fix_all_hyphenation_order():
+    text = "This is a hy-\nphenated line."  # hyphenation across newline
+    # Using the all-fix pathway
+    data = {"text": text, "fix_type": "all"}
+    with app.app.test_client() as client:
+        response = client.post('/fix_text', json=data)
+        fixed = response.get_json()['fixed_text']
+
+    assert fixed == "This is a hyphenated line."


### PR DESCRIPTION
## Summary
- fix `fix_text` to handle hyphenated line breaks correctly
- add regression test for text cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f903342b4832fb0d6f84f7ee855be